### PR TITLE
Add hebrew3 extra model from hugging face (our best model, but twice as large), fix global variable, add caching

### DIFF
--- a/phonemize_wer.py
+++ b/phonemize_wer.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from jiwer import cer, wer
 from tqdm import tqdm
 
-from phonemizers import charisiu, phonikud_phonemizer, espeak, goruut, goruut_0_6_3, nakdimon_phonikud, dicta_phonikud, dicta_naive, nakdimon_naive, phonikud_naive
+from phonemizers import charisiu, phonikud_phonemizer, espeak, goruut, goruut_0_6_3, goruut_0_6_3_extra, nakdimon_phonikud, dicta_phonikud, dicta_naive, nakdimon_naive, phonikud_naive
 
 phonemizers = {
     "phonikud": phonikud_phonemizer.phonemize,
@@ -18,6 +18,7 @@ phonemizers = {
     # "charisiu": charisiu.phonemize,
     # "goruut": goruut.phonemize,
     # "goruut_0_6_3": goruut_0_6_3.phonemize,
+    # "goruut_0_6_3_extra": goruut_0_6_3_extra.phonemize,
     # "nakdimon_phonikud": nakdimon_phonikud.phonemize,
     # "dicta_phonikud": dicta_phonikud.phonemize,
     # "dicta_naive": dicta_naive.phonemize,  # Placeholder for Dicta Naive, not implemented

--- a/phonemizers/goruut.py
+++ b/phonemizers/goruut.py
@@ -11,7 +11,7 @@ pygoruut = None
 def phonemize(sentence: str) -> str:
     global pygoruut
     if pygoruut is None:
-        pygoruut = Pygoruut()
+        pygoruut = Pygoruut(writeable_bin_dir='')
 
     return str(pygoruut.phonemize(language="Hebrew", sentence=sentence))
 

--- a/phonemizers/goruut_0_6_3.py
+++ b/phonemizers/goruut_0_6_3.py
@@ -11,7 +11,7 @@ pygoruut063 = None
 def phonemize(sentence: str) -> str:
     global pygoruut063
     if pygoruut063 is None:
-        pygoruut063 = Pygoruut(version='v0.6.3')
+        pygoruut063 = Pygoruut(version='v0.6.3', writeable_bin_dir='')
 
     return str(pygoruut063.phonemize(language="Hebrew3", sentence=sentence))
 

--- a/phonemizers/goruut_0_6_3.py
+++ b/phonemizers/goruut_0_6_3.py
@@ -6,14 +6,14 @@ uv pip install pygoruut
 """
 from pygoruut.pygoruut import Pygoruut
 
-pygoruut = None
+pygoruut063 = None
 
 def phonemize(sentence: str) -> str:
-    global pygoruut
-    if pygoruut is None:
-        pygoruut = Pygoruut(version='v0.6.3')
+    global pygoruut063
+    if pygoruut063 is None:
+        pygoruut063 = Pygoruut(version='v0.6.3')
 
-    return str(pygoruut.phonemize(language="Hebrew3", sentence=sentence))
+    return str(pygoruut063.phonemize(language="Hebrew3", sentence=sentence))
 
 # Example usage:
 if __name__ == "__main__":

--- a/phonemizers/goruut_0_6_3_extra.py
+++ b/phonemizers/goruut_0_6_3_extra.py
@@ -12,7 +12,7 @@ def phonemize(sentence: str) -> str:
     global pygoruut063extra
     if pygoruut063extra is None:
         import urllib.request
-        urllib.request.urlretrieve("https://huggingface.co/neurlang/goruut_extra_models/resolve/main/hebrew3.zip", filename="/tmp/hebrew3.zip")
+        urllib.request.urlretrieve("https://huggingface.co/neurlang/goruut_extra_models/resolve/main/hebrew3.zip", filename="/tmp/hebrew3.zip", writeable_bin_dir='')
         pygoruut063extra = Pygoruut(version='v0.6.3', models={"Hebrew3": "/tmp/hebrew3.zip"})
 
     return str(pygoruut063extra.phonemize(language="Hebrew3", sentence=sentence))

--- a/phonemizers/goruut_0_6_3_extra.py
+++ b/phonemizers/goruut_0_6_3_extra.py
@@ -12,8 +12,8 @@ def phonemize(sentence: str) -> str:
     global pygoruut063extra
     if pygoruut063extra is None:
         import urllib.request
-        urllib.request.urlretrieve("https://huggingface.co/neurlang/goruut_extra_models/resolve/main/hebrew3.zip", filename="/tmp/hebrew3.zip", writeable_bin_dir='')
-        pygoruut063extra = Pygoruut(version='v0.6.3', models={"Hebrew3": "/tmp/hebrew3.zip"})
+        urllib.request.urlretrieve("https://huggingface.co/neurlang/goruut_extra_models/resolve/main/hebrew3.zip", filename="/tmp/hebrew3.zip")
+        pygoruut063extra = Pygoruut(version='v0.6.3', models={"Hebrew3": "/tmp/hebrew3.zip"}, writeable_bin_dir='')
 
     return str(pygoruut063extra.phonemize(language="Hebrew3", sentence=sentence))
 

--- a/phonemizers/goruut_0_6_3_extra.py
+++ b/phonemizers/goruut_0_6_3_extra.py
@@ -1,0 +1,22 @@
+"""
+uv pip install pygoruut       
+"""
+"""
+uv pip install pygoruut       
+"""
+from pygoruut.pygoruut import Pygoruut
+
+pygoruut063extra = None
+
+def phonemize(sentence: str) -> str:
+    global pygoruut063extra
+    if pygoruut063extra is None:
+        import urllib.request
+        urllib.request.urlretrieve("https://huggingface.co/neurlang/goruut_extra_models/resolve/main/hebrew3.zip", filename="/tmp/hebrew3.zip")
+        pygoruut063extra = Pygoruut(version='v0.6.3', models={"Hebrew3": "/tmp/hebrew3.zip"})
+
+    return str(pygoruut063extra.phonemize(language="Hebrew3", sentence=sentence))
+
+# Example usage:
+if __name__ == "__main__":
+    print(phonemize("בוקר טוב"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "phonemizer-fork>=3.3.2",
     "phonikud",
     "phonikud-onnx>=1.0.1",
-    "pygoruut>=0.6.3",
+    "pygoruut>=0.6.5",
     "torch>=2.7.0",
     "tqdm>=4.67.1",
     "transformers>=4.52.4",

--- a/uv.lock
+++ b/uv.lock
@@ -757,7 +757,7 @@ requires-dist = [
     { name = "phonemizer-fork", specifier = ">=3.3.2" },
     { name = "phonikud", git = "https://github.com/thewh1teagle/phonikud" },
     { name = "phonikud-onnx", specifier = ">=1.0.1" },
-    { name = "pygoruut", specifier = ">=0.6.3" },
+    { name = "pygoruut", specifier = ">=0.6.5" },
     { name = "torch", specifier = ">=2.7.0" },
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "transformers", specifier = ">=4.52.4" },
@@ -779,14 +779,14 @@ wheels = [
 
 [[package]]
 name = "pygoruut"
-version = "0.6.3"
+version = "0.6.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/7d/d74d63282a47e7ccba573a846b2ecd7b21997bbe40cb78bbf253fe5dc77e/pygoruut-0.6.3.tar.gz", hash = "sha256:adec86b762360caa65e958ec2c3f0a51587003a3cb7bbaf28c26de8aa5e3d4c9", size = 24168, upload-time = "2025-08-02T06:34:57.308Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/36/fa2c1113850c98f15a666f4a54b60b65ffb211726e4644e1971f3a190df2/pygoruut-0.6.5.tar.gz", hash = "sha256:de1835a402c91c2d603a44e6dca8663242c1caa0538289ed20c0dfdad19856b9", size = 24668, upload-time = "2025-08-06T15:58:19.019Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/57/7f139d8b60a2cddc0e9d77ff6a3ce9708da4e6cc5f8b83ab6057dbc1d246/pygoruut-0.6.3-py3-none-any.whl", hash = "sha256:7e6f196641ce1b4480e8313d30ac51d609ad93def13f59f0e4719a9dfc242a70", size = 21150, upload-time = "2025-08-02T06:34:55.672Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/e8/96cfa03907725369d025feb6aa1be5f4cf264c0efaf87f9c82fbe3e2766e/pygoruut-0.6.5-py3-none-any.whl", hash = "sha256:1bfde53cf3143354cf3c08bfade809f2cd4bf5649e14fefd689de8426ff4cfda", size = 21455, upload-time = "2025-08-06T15:58:18.243Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Bumps pygoruut to have the ability to **load extra models**
- Add **hebrew3 extra model** from hugging face (our best model, but twice as large)
- Bugfix: Give pygoruut **global variable an unique name** to prevent being clobbered (no idea if pygoruut global variable could be overwritten from the other python file)
- Enable caching - no effect on WER/CER (it's a **good idea to use caching** - to save download and be faster on every successive `uv run ./phonemize_wer.py`)

The wer of extra model was measured as our best result:
```json
{
  "goruut": {
    "avg_cer": 0.4885,
    "avg_wer": 1.0011,
    "avg_wer_without_stress": 0.9515
  },
  "goruut_0_6_3": {
    "avg_cer": 0.0982,
    "avg_wer": 0.382,
    "avg_wer_without_stress": 0.3465
  },
  "goruut_0_6_3_extra": {
    "avg_cer": 0.0978,
    "avg_wer": 0.3818,
    "avg_wer_without_stress": 0.3486
  }
}
```